### PR TITLE
Seeded Random Number Generator

### DIFF
--- a/school_center.py
+++ b/school_center.py
@@ -132,7 +132,11 @@ parser.add_argument('schools_tsv', default='schools.tsv', help="Tab separated (T
 parser.add_argument('centers_tsv', default='centers.tsv', help="Tab separated (TSV) file containing center details")
 parser.add_argument('prefs_tsv', default='prefs.tsv', help="Tab separated (TSV) file containing preference scores")
 parser.add_argument('-o', '--output', default='school-center.tsv', help='Output file')
+parser.add_argument('-s', '--seed', action='store', metavar='SEEDVALUE', default=None, type=float, help='Initialization seed for Random Number Generator')
+
 args = parser.parse_args()
+
+random = random.Random(args.seed) #overwrites the random module to use seeded rng
 
 schools = sorted(read_tsv(args.schools_tsv), key= school_sort_key)
 centers = read_tsv(args.centers_tsv)


### PR DESCRIPTION
Added optional cmdline parameter -s, --seed to generate random number with seed value, useful to verify test cases.

The program always return same output when run with same SEEDVALUE and same input value. i.e. the result become deterministic. This is useful to verify the correctness of program by testing the output against same input and same SEEDVALUE when changes are introduced in the algorithm. 

When --seed parameter is not provided, reverts to python default implementation to generate random number. 
