### PR TITLE
fix: correct version assignment in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ruff==0.4.1
 pytest==8.0.2
-pytest-clarity=1.0.1
+pytest-clarity==1.0.1
 pytest-sugar==1.0.0
 pre-commit==3.6.0
 pytest-cov==5.0.0


### PR DESCRIPTION
There's a missing "=" in the requirements.txt file which will raise a "**Invalid Requirement**" error when installing with pip. 