### PR TITLE
Fix: Output file not properly handled

### DIFF
--- a/school_center.py
+++ b/school_center.py
@@ -161,8 +161,9 @@ remaining = 0 # stores count of non allocated students
 allocations = {}  # to track mutual allocations
 
 create_dir(OUTPUT_DIR) # Create the output directory if not exists
+output_file_path = os.path.join(OUTPUT_DIR, args.output)
 with open('{}school-center-distance.tsv'.format(OUTPUT_DIR), 'w', encoding='utf-8') as intermediate_file, \
-open(OUTPUT_DIR + args.output, 'w', encoding='utf-8') as a_file:
+open(output_file_path, 'w', encoding='utf-8') as a_file:
     writer = csv.writer(intermediate_file, delimiter="\t")
     writer.writerow(["scode", "s_count", "school_name", "school_lat", "school_long", "cscode", "center_name", "center_address", "center_capacity", "distance_km"])
     


### PR DESCRIPTION
The issue of output directory facing error occurred due to the assumption that the "OUTPUT_DIR" variable always contains the full path to the output directory. So, when specifying a subdirectory as part of the command-line argument for the output file (-o option), this assumption breaks.

With this modification, the code will properly handle the output directory structure, whether it's a full path or a subdirectory provided by the user as a command-line argument. This should resolve the "Directory not found" error.