### PR TITLE
Fix path separator for cross-platform compatibility

### DIFF
--- a/utils/custom_logger.py
+++ b/utils/custom_logger.py
@@ -8,7 +8,7 @@ from os.path import abspath, dirname, join, exists
 
 ROOT_DIR: str = abspath(dirname(dirname(__file__)))
 LOGS_DIR: str = join(ROOT_DIR, "logs")
-LOGS_TARGET: str = join(ROOT_DIR, "logs", "custom_logs.log")
+LOGS_TARGET: str = os.path.join(LOGS_DIR, "custom_logs.log")
 CUSTOM_FILE_HANDLER_PATH = "utils.custom_file_handler.CustomFileHandler"
 
 if not exists(LOGS_DIR):


### PR DESCRIPTION
In existing code path to a logfile is hardcoded.To ensure robustness across different platforms, this PR replaces the hardcoded path separator with the os.path.join function, which automatically selects the appropriate separator based on the operating system.