### PR TITLE
fix/output directory generation not working as expected.

### DIFF
--- a/school_center.py
+++ b/school_center.py
@@ -207,8 +207,8 @@ allocations = {}    # to track mutual allocations
 
 OUTPUT_DIR = 'results/'
 create_dir(OUTPUT_DIR)  # Create the output directory if not exists
-with open('{}school-center-distance.tsv'.format(OUTPUT_DIR), 'w', encoding='utf-8') as intermediate_file, \
-        open(OUTPUT_DIR + args.output, 'w', encoding='utf-8') as a_file:
+with open(os.path.join(OUTPUT_DIR, 'school-center-distance.tsv'), 'w', encoding='utf-8') as intermediate_file, \
+        open(os.path.join(OUTPUT_DIR, args.output), 'w', encoding='utf-8') as a_file:
     writer = csv.writer(intermediate_file, delimiter="\t")
     writer.writerow(["scode", 
                      "s_count", 


### PR DESCRIPTION
It appears that OUTPUT_DIR is the base directory, and you're trying to create two files within it. However, when you're specifying the file paths for writing, you're not directly referencing OUTPUT_DIR for the second file.

You're using args.output, which only contains the filename, not the full path. To ensure that both files are created within the OUTPUT_DIR, you should use os.path.join() to construct the full file paths

```
create_dir(OUTPUT_DIR) # Create the output directory if not exists
with open(os.path.join(OUTPUT_DIR, 'school-center-distance.tsv'), 'w', encoding='utf-8') as intermediate_file, \
open(os.path.join(OUTPUT_DIR, args.output), 'w', encoding='utf-8') as a_file:
```

This way, both files will be created within the OUTPUT_DIR, resolving the issue with the output directory generation.
