### PR TITLE
[Enhancement] #83 Improvement of Streamlit Interface for School/Center Searching

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,21 +158,22 @@ if st.session_state.calculate_clicked and st.session_state.calculation_completed
 
         # Display an input field based on the selected filter type
         if st.session_state.filter_type:
-            if st.session_state.filter_type == 'school':
-                # Create filter options with school name and code
-                filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['school'], df_school_center['scode'])]
-                 # Display a selectbox for school selection
-                st.session_state.filter_value = tab1.selectbox(f"Select a value for {st.session_state.filter_type}:", filter_options)
-                # Split the selected value to extract school name and code
-                school_name_with_address, school_code = st.session_state.filter_value.split(' | ')
-                # Filter the DataFrame based on school name
-                filtered_df = filter_data(df_school_center, 'school', school_name_with_address)
-      
-            elif st.session_state.filter_type == 'center':
-                center_filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['center'], df_school_center['cscode'])]
-                st.session_state.filter_value = tab1.selectbox(f"Select a value for {st.session_state.filter_type}:", center_filter_options)
-                center_name, centre_code = st.session_state.filter_value.split(' | ')
-                filtered_df = filter_data(df_school_center, 'center', center_name)
+         if st.session_state.filter_type == 'school':
+          # Create filter options with school name and code
+          filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['school'], df_school_center['scode'])]
+
+         elif st.session_state.filter_type == 'center':
+          # Create filter options with center name and code
+          filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['center'], df_school_center['cscode'])]
+
+         # Display a selectbox for selection
+         st.session_state.filter_value = tab1.selectbox(f"Select a value for {st.session_state.filter_type}:", filter_options)
+
+         # Split the selected value to extract name and code
+         name, code = st.session_state.filter_value.split(' | ')
+
+         # Filter the DataFrame based on the selected type and value
+         filtered_df = filter_data(df_school_center, st.session_state.filter_type, name)
 
         if st.session_state.filter_value:
             tab1.dataframe(filtered_df)

--- a/app.py
+++ b/app.py
@@ -160,11 +160,11 @@ if st.session_state.calculate_clicked and st.session_state.calculation_completed
         if st.session_state.filter_type:
          if st.session_state.filter_type == 'school':
           # Create filter options with school name and code
-          filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['school'], df_school_center['scode'])]
+          filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['school'].unique(), df_school_center['scode'].unique())]
 
          elif st.session_state.filter_type == 'center':
           # Create filter options with center name and code
-          filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['center'], df_school_center['cscode'])]
+          filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['center'].unique(), df_school_center['cscode'].unique())]
 
          # Display a selectbox for selection
          st.session_state.filter_value = tab1.selectbox(f"Select a value for {st.session_state.filter_type}:", filter_options)
@@ -176,7 +176,7 @@ if st.session_state.calculate_clicked and st.session_state.calculation_completed
          filtered_df = filter_data(df_school_center, st.session_state.filter_type, name)
 
         if st.session_state.filter_value:
-            tab1.dataframe(filtered_df)
+            tab1.dataframe(filtered_df, hide_index=True)
             tab1.subheader('Map')
             tab1.divider()
             for index, center in filtered_df.iterrows():

--- a/app.py
+++ b/app.py
@@ -160,17 +160,17 @@ if st.session_state.calculate_clicked and st.session_state.calculation_completed
         if st.session_state.filter_type:
          if st.session_state.filter_type == 'school':
           # Create filter options with school name and code
-          filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['school'].unique(), df_school_center['scode'].unique())]
+          filter_options = [f"{code} | {name}" for name, code in zip(df_school_center['school'].unique(), df_school_center['scode'].unique())]
 
          elif st.session_state.filter_type == 'center':
           # Create filter options with center name and code
-          filter_options = [f"{name} | [{code}]" for name, code in zip(df_school_center['center'].unique(), df_school_center['cscode'].unique())]
+          filter_options = [f"{code} | {name}" for name, code in zip(df_school_center['center'].unique(), df_school_center['cscode'].unique())]
 
          # Display a selectbox for selection
          st.session_state.filter_value = tab1.selectbox(f"Select a value for {st.session_state.filter_type}:", filter_options)
 
          # Split the selected value to extract name and code
-         name, code = st.session_state.filter_value.split(' | ')
+         code, name = st.session_state.filter_value.split(' | ')
 
          # Filter the DataFrame based on the selected type and value
          filtered_df = filter_data(df_school_center, st.session_state.filter_type, name)

--- a/app.py
+++ b/app.py
@@ -199,8 +199,6 @@ if st.session_state.calculate_clicked and st.session_state.calculation_completed
         
         tab1.divider()
         tab1.subheader('All Data')
-        # df_school_center = df_school_center.replace(',','', regex=True)
-        # print(df_school_center)
         tab1.dataframe(df_school_center)
     else:
         tab1.info("No calculated data available.", icon="ℹ️")

--- a/app.py
+++ b/app.py
@@ -176,7 +176,12 @@ if st.session_state.calculate_clicked and st.session_state.calculation_completed
          filtered_df = filter_data(df_school_center, st.session_state.filter_type, name)
 
         if st.session_state.filter_value:
-            tab1.dataframe(filtered_df, hide_index=True)
+            # Remove thousand separator comma in scode and cscode 
+            styled_df  = filtered_df.style.format({
+              "cscode": lambda x: '{:.0f}'.format(x),
+               "scode": lambda x: '{:.0f}'.format(x)
+            })
+            tab1.dataframe(styled_df , hide_index=True)
             tab1.subheader('Map')
             tab1.divider()
             for index, center in filtered_df.iterrows():
@@ -194,6 +199,8 @@ if st.session_state.calculate_clicked and st.session_state.calculation_completed
         
         tab1.divider()
         tab1.subheader('All Data')
+        # df_school_center = df_school_center.replace(',','', regex=True)
+        # print(df_school_center)
         tab1.dataframe(df_school_center)
     else:
         tab1.info("No calculated data available.", icon="ℹ️")
@@ -201,6 +208,7 @@ if st.session_state.calculate_clicked and st.session_state.calculation_completed
     if 'school_center_distance' in st.session_state.calculated_data:
         df = pd.read_csv(st.session_state.calculated_data['school_center_distance'], sep="\t")
         tab2.dataframe(df)
+
     else:
         tab2.error("School Center Distance file not found.")
 


### PR DESCRIPTION
Fixes #83 

Task Done:

- Instead of four radio buttons options scode | school | cscode | center, could we just keep two school | center and show the code along side the school/center name.

- Also make it searchable by both name and code.

- Use horizontal layout for radio options for efficient use of screen space: For this i have added a custom css

- Do not use thousand separator comma (27,056) in scode / cscode

- Show Only Unique School,Center,scode,cscode values in filter dropdown and hide index of the filtered table

